### PR TITLE
fix bound method call to pass self

### DIFF
--- a/discord/ext/alternatives/silent_delete.py
+++ b/discord/ext/alternatives/silent_delete.py
@@ -11,7 +11,7 @@ _old_delete = Message.delete
 
 async def delete(self, *, delay=None, silent=False):
     try:
-        await _old_delete(delay=delay)
+        await _old_delete(self, delay=delay)
     except Exception:
         if not silent:
             raise


### PR DESCRIPTION
### Description
<!-- a clear description of what this PR does. -->

the internal `_old_delete` in the silent_delete alternative is an unbound method, and as such must be passed an instance when being called.

### Checklist
<!-- put an x inside [ ] to check it, like so: [x] -->

- [x] This PR makes changes to the code.
    - [ ] The changes are breaking.
    - [ ] The changes implement a new feature.
    - [x] The changes fix an issue.
    - [ ] I updated the documentation to reflect these changes.
- [ ] This PR makes changes to the documentation.
    - [ ] The changes require a different version of sphinx.
    - [ ] I updated the configuration file to reflect these changes.

<!-- all pull requests should be tested. -->
- [x] This PR has been tested.
