### PR TITLE
Fix delete() missing self

### DIFF
--- a/discord/ext/alternatives/silent_delete.py
+++ b/discord/ext/alternatives/silent_delete.py
@@ -11,7 +11,7 @@ _old_delete = Message.delete
 
 async def delete(self, *, delay=None, silent=False):
     try:
-        await _old_delete(delay=delay)
+        await _old_delete(self, delay=delay)
     except Exception:
         if not silent:
             raise


### PR DESCRIPTION
### Description
Silent delete is not actually working because self is not being passed (therefore it doesn't know *what* to delete. This fixes that. 

This is the actual traceback which caused me to notice the bug.
```py
Sep 13 19:17:08 trainerdex-beta-0 python[2319040]: [2020-09-13 19:17:08] [ERROR] red: Exception in command 'profile edit visible'
Sep 13 19:17:08 trainerdex-beta-0 python[2319040]: Traceback (most recent call last):
Sep 13 19:17:08 trainerdex-beta-0 python[2319040]:   File "/opt/DiscordBot/env/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
Sep 13 19:17:08 trainerdex-beta-0 python[2319040]:     ret = await coro(*args, **kwargs)
Sep 13 19:17:08 trainerdex-beta-0 python[2319040]:   File "/opt/DiscordBot/tdx/profile.py", line 210, in profile__edit__visible
Sep 13 19:17:08 trainerdex-beta-0 python[2319040]:     await ctx.send(
Sep 13 19:17:08 trainerdex-beta-0 python[2319040]:   File "/opt/DiscordBot/env/lib/python3.8/site-packages/redbot/core/commands/context.py", line 93, in send
Sep 13 19:17:08 trainerdex-beta-0 python[2319040]:     return await super().send(content=content, **kwargs)
Sep 13 19:17:08 trainerdex-beta-0 python[2319040]:   File "/opt/DiscordBot/env/lib/python3.8/site-packages/discord/abc.py", line 895, in send
Sep 13 19:17:08 trainerdex-beta-0 python[2319040]:     await ret.delete(delay=delete_after)
Sep 13 19:17:08 trainerdex-beta-0 python[2319040]:   File "/opt/DiscordBot/env/lib/python3.8/site-packages/discord/ext/alternatives/silent_delete.py", line 14, in delete
Sep 13 19:17:08 trainerdex-beta-0 python[2319040]:     await _old_delete(delay=delay)
Sep 13 19:17:08 trainerdex-beta-0 python[2319040]: TypeError: delete() missing 1 required positional argument: 'self'
```

The `delete()` was called with `ctx.send("...", delete_after=30)`

### Checklist
- [x] This PR makes changes to the code.
    - [ ] The changes are breaking.
    - [ ] The changes implement a new feature.
    - [x] The changes fix an issue.
    - [ ] I updated the documentation to reflect these changes.
- [ ] This PR makes changes to the documentation.
    - [ ] The changes require a different version of sphinx.
    - [ ] I updated the configuration file to reflect these changes.

<!-- all pull requests should be tested. -->
- [x] This PR has been tested.
