### PR TITLE
Fix issue with converter_dict and typing.Union

### DIFF
--- a/discord/ext/alternatives/converter_dict.py
+++ b/discord/ext/alternatives/converter_dict.py
@@ -73,15 +73,10 @@ _GLOBAL_CONVERTER_DICT = _ConverterDict()
 
 Bot.converters = _GLOBAL_CONVERTER_DICT
 
-def _get_converter(self, param):
-    obj = param.annotation
-    if obj is param.empty:
-        if param.default is not param.empty:
-            converter = _GLOBAL_CONVERTER_DICT.get(type(param.default), str)
-        else:
-            converter = str
-    else:
-        converter = _GLOBAL_CONVERTER_DICT.get(obj, obj) # fall back on its typehint if its converter isn't registered
-    return converter
+_old_actual_conversion = Command._actual_conversion
 
-Command._get_converter = _get_converter
+async def _actual_conversion(self, ctx, converter, argument, param):
+    converter = _GLOBAL_CONVERTER_DICT.get(converter, converter)
+    return await _old_actual_conversion(self, ctx, converter, argument, param)
+
+Command._actual_conversion = _actual_conversion


### PR DESCRIPTION
### Description
Enables converter_dict defined converters to function inside a typing.Union

### Checklist
<!-- put an x inside [ ] to check it, like so: [x] -->

- [x] This PR makes changes to the code.
    - [ ] The changes are breaking.
    - [ ] The changes implement a new feature.
    - [x] The changes fix an issue.
    - [ ] I updated the documentation to reflect these changes.
- [ ] This PR makes changes to the documentation.
    - [ ] The changes require a different version of sphinx.
    - [ ] I updated the configuration file to reflect these changes.

<!-- all pull requests should be tested. -->
- [x] This PR has been tested.
