### PR TITLE
Fix TypeError when using @commands.check_any()

### DIFF
--- a/discord/ext/alternatives/binary_checks.py
+++ b/discord/ext/alternatives/binary_checks.py
@@ -53,6 +53,7 @@ py_allow(3, 9, 0)
 
 class CheckDecorator:
     def __init__(self, predicate):
+        self.predicate = predicate
         self.check = Only(Check(predicate))
     
     def __call__(self, func):


### PR DESCRIPTION
### Description
The Exception thrown [here](https://github.com/Rapptz/discord.py/blob/6524869ddd283a1704d0eec9bc87b2663c247d01/discord/ext/commands/core.py#L1588-L1591) happens because `CheckDecorator` has no `self.predicate`.

This fixes that.

### Checklist
- [x] This PR has been tested.
